### PR TITLE
Cosmetic changes

### DIFF
--- a/app/src/main/java/com/example/android/classicalmusicquiz/QuizActivity.java
+++ b/app/src/main/java/com/example/android/classicalmusicquiz/QuizActivity.java
@@ -189,6 +189,9 @@ public class QuizActivity extends AppCompatActivity {
 
         // MySessionCallback has methods that handle callbacks from a media controller.
         mMediaSession.setCallback(new MySessionCallback());
+
+        // we are in foreground and ready to play
+        mMediaSession.setActive(true);
     }
 
     /**
@@ -363,7 +366,6 @@ public class QuizActivity extends AppCompatActivity {
                 mStateBuilder.setState(PlaybackStateCompat.STATE_PLAYING,
                     mExoPlayer.getCurrentPosition(), 1f);
                 mMediaSession.setPlaybackState(mStateBuilder.build());
-                mMediaSession.setActive(true);
             } else if((playbackState == ExoPlayer.STATE_READY)){
                 mStateBuilder.setState(PlaybackStateCompat.STATE_PAUSED,
                     mExoPlayer.getCurrentPosition(), 1f);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="play">Play</string>
     <string name="pause">Pause</string>
     <string name="restart">Restart</string>
+    <string name="sample_not_found_error">Sample %1$d not found</string>
 </resources>


### PR DESCRIPTION
I did a couple of cosmetic changes. In general everything ExoPlayer releated is correct. There is nothing I could complain about :)

In general my suggestion and changes are nit, some are supernit. Don't get me wrong. These are suggestions of mine, so hey, cherry-pick what you agree on.

functional changes
------------------------------
There is one thing I changed regarding activating the MediaSession. I would put it on active as soon as you created the session. From that moment on we are ready to receive media commands through the session and act upon such commands.

cosmetic changes
------------------------------
- I created an inner class ComponentListener which implements the interfaces you implemented on the Activity level. There is nothing really wrong about your approach. I prefer the private inner class because it does not expose the API of the implemented interfaces to the outside world. Having all the exoPlayer.Listener methods exposed by the Activity would clutter the API of a class a little. 

- I created a initializePlayer and releasePlayer method for clarity like you did for the MediaSession

- changed the error string in case a sample could not be found (it's not an player issue as the previous message suggested)

- I inlined most of the objects which are just created and used once. Saves some lines of code and is IMO still readable very nicely.

suggested changes
------------------------------
- I wanted to change the sample to initialize/release the player on start/resume/pause/stop like the PlayerActivity of the demo app does. This implementation takes care to release codec resources as soon as in background. However, your approach works very well with letting the player play in the background. The notification still lets the user know where the audible music comes from even if he changes to another app (for a video app I would do it like the demo app does, but that's another story). For having it IMO super correct it would be nice to make the app coming to the foreground when the notification is tapped by the user. So it's very easy for the user to get to the app which is doing that music in the background (even if he forgot about the app).

- there are some indentations I would change to follow one style but I do not exactly know the code conventions for Udacity samples. I'm little addicted to have such things right. Surely up to you :)